### PR TITLE
Update to HTTPS URLs

### DIFF
--- a/backend/cron-dl.sh
+++ b/backend/cron-dl.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-SEQ=`wget -o /dev/null -O /dev/stdout http://planet.openstreetmap.org/replication/minute/state.txt|grep sequenceNumber|cut -d '=' -f 2`
+SEQ=`wget -o /dev/null -O /dev/stdout https://planet.openstreetmap.org/replication/minute/state.txt|grep sequenceNumber|cut -d '=' -f 2`
 
 MM=$[$SEQ/1000000]
 KK=$[$SEQ-$MM*1000000]
@@ -12,4 +12,4 @@ C=`printf %03d $UU`
 
 echo $A/$B/$C
 
-wget -o /dev/null -O /dev/stdout http://planet.openstreetmap.org/replication/minute/$A/$B/$C.osc.gz|gunzip -c|python compute-changeset-data.py
+wget -o /dev/null -O /dev/stdout https://planet.openstreetmap.org/replication/minute/$A/$B/$C.osc.gz|gunzip -c|python compute-changeset-data.py


### PR DESCRIPTION
planet.openstreetmap.org will redirect to HTTPS at some point in the future. Without this change, your replication might break, or at best, need an extra round-trip for the redirect.

See also openstreetmap/operations#200